### PR TITLE
feat(tab): add tab notation display toggle

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -202,3 +202,8 @@
     border-color: var(--color-playable-border);
   }
 }
+
+.toggleGroup {
+  display: flex;
+  gap: 0.5rem;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,12 +5,15 @@ import { AVAILABLE_KEYS, SCALE_TYPES, TUNING_TYPES, getHarmonicaPosition } from 
 import { useHarmonicaScale } from './hooks/useHarmonicaScale'
 import { HoleColumn } from './components/HoleColumn'
 
+export type NoteDisplayMode = 'notes' | 'tab'
+
 function App() {
   const [harmonicaKey, setHarmonicaKey] = useState<HarmonicaKey>('C')
   const [songKey, setSongKey] = useState<HarmonicaKey>('C')
   const [scaleType, setScaleType] = useState<ScaleType>('major')
   const [tuning, setTuning] = useState<TuningType>('richter')
   const [showDegrees, setShowDegrees] = useState(false)
+  const [noteDisplay, setNoteDisplay] = useState<NoteDisplayMode>('notes')
 
   const { harmonica, scaleNotes, playableBlowHoles, playableDrawHoles } = useHarmonicaScale(
     harmonicaKey,
@@ -125,6 +128,7 @@ function App() {
                 isBlowPlayable={playableBlowHoles.includes(hole.hole)}
                 isDrawPlayable={playableDrawHoles.includes(hole.hole)}
                 showDegrees={showDegrees}
+                noteDisplay={noteDisplay}
               />
             ))}
           </div>
@@ -132,13 +136,22 @@ function App() {
           <div className={styles.legend} role="note" aria-label="Legend for scale visualization">
             <div className={styles.legendHeader}>
               <h3>Legend</h3>
-              <button
-                className={`${styles.toggleButton} ${showDegrees ? styles.toggleActive : ''}`}
-                onClick={() => setShowDegrees(!showDegrees)}
-                aria-pressed={showDegrees}
-              >
-                {showDegrees ? 'Hide' : 'Show'} Degrees
-              </button>
+              <div className={styles.toggleGroup}>
+                <button
+                  className={`${styles.toggleButton} ${noteDisplay === 'tab' ? styles.toggleActive : ''}`}
+                  onClick={() => setNoteDisplay(noteDisplay === 'notes' ? 'tab' : 'notes')}
+                  aria-pressed={noteDisplay === 'tab'}
+                >
+                  {noteDisplay === 'notes' ? 'Show' : 'Hide'} Tab
+                </button>
+                <button
+                  className={`${styles.toggleButton} ${showDegrees ? styles.toggleActive : ''}`}
+                  onClick={() => setShowDegrees(!showDegrees)}
+                  aria-pressed={showDegrees}
+                >
+                  {showDegrees ? 'Hide' : 'Show'} Degrees
+                </button>
+              </div>
             </div>
             <div className={styles.legendItems}>
               <div className={styles.legendItem}>

--- a/src/components/HoleColumn.tsx
+++ b/src/components/HoleColumn.tsx
@@ -2,6 +2,8 @@ import { memo } from 'react'
 import type { HoleNote } from '../data/harmonicas'
 import { isNoteInScale, getNoteDegree, degreeToRoman } from '../data/scales'
 import { playTone } from '../utils/audioPlayer'
+import { getTabNotation, labelToNoteType } from '../utils/tabNotation'
+import type { NoteDisplayMode } from '../App'
 import type { NoteNames } from '../types'
 import styles from './HoleColumn.module.css'
 
@@ -12,9 +14,11 @@ interface NoteSectionProps {
   isPlayable: boolean
   showDegrees: boolean
   scaleNotes: NoteNames
+  holeNumber: number
+  displayMode: NoteDisplayMode
 }
 
-const NoteSection = ({ label, note, frequency, isPlayable, showDegrees, scaleNotes }: NoteSectionProps) => {
+const NoteSection = ({ label, note, frequency, isPlayable, showDegrees, scaleNotes, holeNumber, displayMode }: NoteSectionProps) => {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
@@ -24,6 +28,10 @@ const NoteSection = ({ label, note, frequency, isPlayable, showDegrees, scaleNot
 
   const degree = showDegrees && isPlayable ? getNoteDegree(note, scaleNotes) : undefined
   const romanNumeral = degree ? degreeToRoman(degree) : undefined
+
+  const noteType = labelToNoteType(label)
+  const tabNotation = getTabNotation(holeNumber, noteType)
+  const displayText = displayMode === 'tab' ? tabNotation : note
 
   return (
     <div
@@ -37,7 +45,7 @@ const NoteSection = ({ label, note, frequency, isPlayable, showDegrees, scaleNot
       <div className={styles.label}>{label}</div>
       <div className={styles.noteDisplay}>
         {romanNumeral && <div className={styles.degree}>{romanNumeral}</div>}
-        <div className={styles.note}>{note}</div>
+        <div className={styles.note}>{displayText}</div>
       </div>
     </div>
   )
@@ -49,6 +57,7 @@ interface HoleColumnProps {
   isBlowPlayable: boolean
   isDrawPlayable: boolean
   showDegrees: boolean
+  noteDisplay: NoteDisplayMode
 }
 
 export const HoleColumn = memo(function HoleColumn({
@@ -57,6 +66,7 @@ export const HoleColumn = memo(function HoleColumn({
   isBlowPlayable,
   isDrawPlayable,
   showDegrees,
+  noteDisplay,
 }: HoleColumnProps) {
   const isOverblowPlayable = hole.overblow && isNoteInScale(hole.overblow.note, scaleNotes)
   const isBlowWholeStepPlayable =
@@ -83,6 +93,8 @@ export const HoleColumn = memo(function HoleColumn({
             isPlayable={!!isOverblowPlayable}
             showDegrees={showDegrees}
             scaleNotes={scaleNotes}
+            holeNumber={hole.hole}
+            displayMode={noteDisplay}
           />
         )}
         {hole.blowBends?.wholeStepBend && (
@@ -93,6 +105,8 @@ export const HoleColumn = memo(function HoleColumn({
             isPlayable={!!isBlowWholeStepPlayable}
             showDegrees={showDegrees}
             scaleNotes={scaleNotes}
+            holeNumber={hole.hole}
+            displayMode={noteDisplay}
           />
         )}
         {hole.blowBends?.halfStepBend && (
@@ -103,6 +117,8 @@ export const HoleColumn = memo(function HoleColumn({
             isPlayable={!!isBlowHalfStepPlayable}
             showDegrees={showDegrees}
             scaleNotes={scaleNotes}
+            holeNumber={hole.hole}
+            displayMode={noteDisplay}
           />
         )}
         {/* Blow Note - Middle */}
@@ -113,6 +129,8 @@ export const HoleColumn = memo(function HoleColumn({
           isPlayable={isBlowPlayable}
           showDegrees={showDegrees}
           scaleNotes={scaleNotes}
+          holeNumber={hole.hole}
+          displayMode={noteDisplay}
         />
       </div>
 
@@ -129,6 +147,8 @@ export const HoleColumn = memo(function HoleColumn({
           isPlayable={isDrawPlayable}
           showDegrees={showDegrees}
           scaleNotes={scaleNotes}
+          holeNumber={hole.hole}
+          displayMode={noteDisplay}
         />
         {hole.drawBends?.halfStepBend && (
           <NoteSection
@@ -138,6 +158,8 @@ export const HoleColumn = memo(function HoleColumn({
             isPlayable={!!isDrawHalfStepPlayable}
             showDegrees={showDegrees}
             scaleNotes={scaleNotes}
+            holeNumber={hole.hole}
+            displayMode={noteDisplay}
           />
         )}
         {hole.drawBends?.wholeStepBend && (
@@ -148,6 +170,8 @@ export const HoleColumn = memo(function HoleColumn({
             isPlayable={!!isDrawWholeStepPlayable}
             showDegrees={showDegrees}
             scaleNotes={scaleNotes}
+            holeNumber={hole.hole}
+            displayMode={noteDisplay}
           />
         )}
         {hole.drawBends?.minorThirdBend && (
@@ -158,6 +182,8 @@ export const HoleColumn = memo(function HoleColumn({
             isPlayable={!!isDrawMinorThirdPlayable}
             showDegrees={showDegrees}
             scaleNotes={scaleNotes}
+            holeNumber={hole.hole}
+            displayMode={noteDisplay}
           />
         )}
         {hole.overdraw && (
@@ -168,6 +194,8 @@ export const HoleColumn = memo(function HoleColumn({
             isPlayable={!!isOverdrawPlayable}
             showDegrees={showDegrees}
             scaleNotes={scaleNotes}
+            holeNumber={hole.hole}
+            displayMode={noteDisplay}
           />
         )}
       </div>

--- a/src/utils/tabNotation.test.ts
+++ b/src/utils/tabNotation.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { getTabNotation, labelToNoteType } from './tabNotation'
+
+describe('getTabNotation', () => {
+  describe('blow notes', () => {
+    it('returns +N for blow notes', () => {
+      expect(getTabNotation(1, 'blow')).toBe('+1')
+      expect(getTabNotation(4, 'blow')).toBe('+4')
+      expect(getTabNotation(10, 'blow')).toBe('+10')
+    })
+  })
+
+  describe('draw notes', () => {
+    it('returns -N for draw notes', () => {
+      expect(getTabNotation(1, 'draw')).toBe('-1')
+      expect(getTabNotation(4, 'draw')).toBe('-4')
+      expect(getTabNotation(10, 'draw')).toBe('-10')
+    })
+  })
+
+  describe('draw bends', () => {
+    it("returns -N' for half-step draw bends", () => {
+      expect(getTabNotation(1, 'drawHalfBend')).toBe("-1'")
+      expect(getTabNotation(4, 'drawHalfBend')).toBe("-4'")
+    })
+
+    it("returns -N'' for whole-step draw bends", () => {
+      expect(getTabNotation(2, 'drawWholeBend')).toBe("-2''")
+      expect(getTabNotation(3, 'drawWholeBend')).toBe("-3''")
+    })
+
+    it("returns -N''' for minor third draw bends", () => {
+      expect(getTabNotation(2, 'drawMinorThirdBend')).toBe("-2'''")
+      expect(getTabNotation(3, 'drawMinorThirdBend')).toBe("-3'''")
+    })
+  })
+
+  describe('blow bends', () => {
+    it("returns +N' for half-step blow bends", () => {
+      expect(getTabNotation(8, 'blowHalfBend')).toBe("+8'")
+      expect(getTabNotation(9, 'blowHalfBend')).toBe("+9'")
+      expect(getTabNotation(10, 'blowHalfBend')).toBe("+10'")
+    })
+
+    it("returns +N'' for whole-step blow bends", () => {
+      expect(getTabNotation(10, 'blowWholeBend')).toBe("+10''")
+    })
+  })
+
+  describe('overblows and overdraws', () => {
+    it('returns OBN for overblows', () => {
+      expect(getTabNotation(1, 'overblow')).toBe('OB1')
+      expect(getTabNotation(4, 'overblow')).toBe('OB4')
+      expect(getTabNotation(6, 'overblow')).toBe('OB6')
+    })
+
+    it('returns ODN for overdraws', () => {
+      expect(getTabNotation(7, 'overdraw')).toBe('OD7')
+      expect(getTabNotation(9, 'overdraw')).toBe('OD9')
+      expect(getTabNotation(10, 'overdraw')).toBe('OD10')
+    })
+  })
+})
+
+describe('labelToNoteType', () => {
+  it('converts Blow label to blow type', () => {
+    expect(labelToNoteType('Blow')).toBe('blow')
+  })
+
+  it('converts Draw label to draw type', () => {
+    expect(labelToNoteType('Draw')).toBe('draw')
+  })
+
+  it('converts bend labels to correct types', () => {
+    expect(labelToNoteType('↑1')).toBe('blowHalfBend')
+    expect(labelToNoteType('↑2')).toBe('blowWholeBend')
+    expect(labelToNoteType('↓1')).toBe('drawHalfBend')
+    expect(labelToNoteType('↓2')).toBe('drawWholeBend')
+    expect(labelToNoteType('↓3')).toBe('drawMinorThirdBend')
+  })
+
+  it('converts OB/OD labels to correct types', () => {
+    expect(labelToNoteType('OB')).toBe('overblow')
+    expect(labelToNoteType('OD')).toBe('overdraw')
+  })
+})

--- a/src/utils/tabNotation.ts
+++ b/src/utils/tabNotation.ts
@@ -1,0 +1,85 @@
+/**
+ * Tab notation utilities for harmonica tablature display.
+ *
+ * Standard harmonica tab format:
+ * - Blow notes: +1 through +10
+ * - Draw notes: -1 through -10
+ * - Draw bends: -4' (half step), -4'' (whole step), -4''' (minor third)
+ * - Blow bends: +8' (half step), +8'' (whole step)
+ * - Overblows: OB1 through OB6
+ * - Overdraws: OD7 through OD10
+ */
+
+export type NoteType =
+  | 'blow'
+  | 'draw'
+  | 'blowHalfBend'
+  | 'blowWholeBend'
+  | 'drawHalfBend'
+  | 'drawWholeBend'
+  | 'drawMinorThirdBend'
+  | 'overblow'
+  | 'overdraw'
+
+/**
+ * Converts a hole number and note type to standard harmonica tab notation.
+ *
+ * @param holeNumber - The harmonica hole number (1-10)
+ * @param noteType - The type of note being played
+ * @returns The tab notation string (e.g., "+4", "-4", "-4'", "OB6")
+ */
+export function getTabNotation(holeNumber: number, noteType: NoteType): string {
+  switch (noteType) {
+    case 'blow':
+      return `+${holeNumber}`
+    case 'draw':
+      return `-${holeNumber}`
+    case 'blowHalfBend':
+      return `+${holeNumber}'`
+    case 'blowWholeBend':
+      return `+${holeNumber}''`
+    case 'drawHalfBend':
+      return `-${holeNumber}'`
+    case 'drawWholeBend':
+      return `-${holeNumber}''`
+    case 'drawMinorThirdBend':
+      return `-${holeNumber}'''`
+    case 'overblow':
+      return `OB${holeNumber}`
+    case 'overdraw':
+      return `OD${holeNumber}`
+    default:
+      return `${holeNumber}`
+  }
+}
+
+/**
+ * Maps the label used in HoleColumn to a NoteType for tab conversion.
+ *
+ * @param label - The display label from HoleColumn (e.g., "Blow", "Draw", "↑1", "↓2")
+ * @returns The corresponding NoteType
+ */
+export function labelToNoteType(label: string): NoteType {
+  switch (label) {
+    case 'Blow':
+      return 'blow'
+    case 'Draw':
+      return 'draw'
+    case '↑1':
+      return 'blowHalfBend'
+    case '↑2':
+      return 'blowWholeBend'
+    case '↓1':
+      return 'drawHalfBend'
+    case '↓2':
+      return 'drawWholeBend'
+    case '↓3':
+      return 'drawMinorThirdBend'
+    case 'OB':
+      return 'overblow'
+    case 'OD':
+      return 'overdraw'
+    default:
+      return 'blow'
+  }
+}


### PR DESCRIPTION
## Summary
- Add harmonica tablature notation (+4, -4, -4') as an alternative to standard note names
- Toggle button in legend area switches between "Notes" and "Tab" display modes
- All note types supported: blow, draw, bends, overblows, overdraws

## Changes
- **New files:**
  - `src/utils/tabNotation.ts` - Tab notation generation utility
  - `src/utils/tabNotation.test.ts` - Comprehensive tests (13 test cases)
- **Modified files:**
  - `src/App.tsx` - Added `NoteDisplayMode` state and toggle button
  - `src/App.module.css` - Added `.toggleGroup` for button layout
  - `src/components/HoleColumn.tsx` - Conditionally render tab or note names

## Tab Notation Format
| Note Type | Example |
|-----------|---------|
| Blow | +4 |
| Draw | -4 |
| Draw bend (half) | -4' |
| Draw bend (whole) | -4'' |
| Draw bend (minor 3rd) | -3''' |
| Blow bend (half) | +8' |
| Overblow | OB6 |
| Overdraw | OD7 |

## Testing
- [x] Unit tests for tab notation generation (13 tests)
- [x] All 110 existing tests pass
- [x] TypeScript build succeeds
- [x] Manual testing in browser

## Test Plan
1. Open app and verify default shows note names (C, D, E, etc.)
2. Click "Show Tab" button in legend
3. Verify notes display as tab notation (+1, -1, -1', etc.)
4. Verify toggle works with "Show Degrees" independently
5. Test on mobile viewport

---
🤖 Generated with [Claude Code](https://claude.ai/code)