### PR TITLE
refactor: add DisplaySettingsContext for global display state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,16 +4,14 @@ import type { HarmonicaKey, ScaleType, TuningType } from './data/harmonicas'
 import { AVAILABLE_KEYS, SCALE_TYPES, TUNING_TYPES, getHarmonicaPosition } from './data/harmonicas'
 import { useHarmonicaScale } from './hooks/useHarmonicaScale'
 import { HoleColumn } from './components/HoleColumn'
+import { DisplaySettingsProvider, useDisplaySettings } from './context'
 
-export type NoteDisplayMode = 'notes' | 'tab'
-
-function App() {
+function AppContent() {
   const [harmonicaKey, setHarmonicaKey] = useState<HarmonicaKey>('C')
   const [songKey, setSongKey] = useState<HarmonicaKey>('C')
   const [scaleType, setScaleType] = useState<ScaleType>('major')
   const [tuning, setTuning] = useState<TuningType>('richter')
-  const [showDegrees, setShowDegrees] = useState(false)
-  const [noteDisplay, setNoteDisplay] = useState<NoteDisplayMode>('notes')
+  const { noteDisplay, showDegrees, setNoteDisplay, setShowDegrees } = useDisplaySettings()
 
   const { harmonica, scaleNotes, playableBlowHoles, playableDrawHoles } = useHarmonicaScale(
     harmonicaKey,
@@ -127,8 +125,6 @@ function App() {
                 scaleNotes={scaleNotes}
                 isBlowPlayable={playableBlowHoles.includes(hole.hole)}
                 isDrawPlayable={playableDrawHoles.includes(hole.hole)}
-                showDegrees={showDegrees}
-                noteDisplay={noteDisplay}
               />
             ))}
           </div>
@@ -167,6 +163,14 @@ function App() {
         </div>
       </main>
     </div>
+  )
+}
+
+function App() {
+  return (
+    <DisplaySettingsProvider>
+      <AppContent />
+    </DisplaySettingsProvider>
   )
 }
 

--- a/src/components/HoleColumn.tsx
+++ b/src/components/HoleColumn.tsx
@@ -3,7 +3,7 @@ import type { HoleNote } from '../data/harmonicas'
 import { isNoteInScale, getNoteDegree, degreeToRoman } from '../data/scales'
 import { playTone } from '../utils/audioPlayer'
 import { getTabNotation, labelToNoteType } from '../utils/tabNotation'
-import type { NoteDisplayMode } from '../App'
+import { useDisplaySettings } from '../context'
 import type { NoteNames } from '../types'
 import styles from './HoleColumn.module.css'
 
@@ -12,13 +12,13 @@ interface NoteSectionProps {
   note: string
   frequency: number
   isPlayable: boolean
-  showDegrees: boolean
   scaleNotes: NoteNames
   holeNumber: number
-  displayMode: NoteDisplayMode
 }
 
-const NoteSection = ({ label, note, frequency, isPlayable, showDegrees, scaleNotes, holeNumber, displayMode }: NoteSectionProps) => {
+const NoteSection = ({ label, note, frequency, isPlayable, scaleNotes, holeNumber }: NoteSectionProps) => {
+  const { showDegrees, noteDisplay } = useDisplaySettings()
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
@@ -31,7 +31,7 @@ const NoteSection = ({ label, note, frequency, isPlayable, showDegrees, scaleNot
 
   const noteType = labelToNoteType(label)
   const tabNotation = getTabNotation(holeNumber, noteType)
-  const displayText = displayMode === 'tab' ? tabNotation : note
+  const displayText = noteDisplay === 'tab' ? tabNotation : note
 
   return (
     <div
@@ -56,8 +56,6 @@ interface HoleColumnProps {
   scaleNotes: NoteNames
   isBlowPlayable: boolean
   isDrawPlayable: boolean
-  showDegrees: boolean
-  noteDisplay: NoteDisplayMode
 }
 
 export const HoleColumn = memo(function HoleColumn({
@@ -65,8 +63,6 @@ export const HoleColumn = memo(function HoleColumn({
   scaleNotes,
   isBlowPlayable,
   isDrawPlayable,
-  showDegrees,
-  noteDisplay,
 }: HoleColumnProps) {
   const isOverblowPlayable = hole.overblow && isNoteInScale(hole.overblow.note, scaleNotes)
   const isBlowWholeStepPlayable =
@@ -91,10 +87,8 @@ export const HoleColumn = memo(function HoleColumn({
             note={hole.overblow.note}
             frequency={hole.overblow.frequency}
             isPlayable={!!isOverblowPlayable}
-            showDegrees={showDegrees}
             scaleNotes={scaleNotes}
             holeNumber={hole.hole}
-            displayMode={noteDisplay}
           />
         )}
         {hole.blowBends?.wholeStepBend && (
@@ -103,10 +97,8 @@ export const HoleColumn = memo(function HoleColumn({
             note={hole.blowBends.wholeStepBend.note}
             frequency={hole.blowBends.wholeStepBend.frequency}
             isPlayable={!!isBlowWholeStepPlayable}
-            showDegrees={showDegrees}
             scaleNotes={scaleNotes}
             holeNumber={hole.hole}
-            displayMode={noteDisplay}
           />
         )}
         {hole.blowBends?.halfStepBend && (
@@ -115,10 +107,8 @@ export const HoleColumn = memo(function HoleColumn({
             note={hole.blowBends.halfStepBend.note}
             frequency={hole.blowBends.halfStepBend.frequency}
             isPlayable={!!isBlowHalfStepPlayable}
-            showDegrees={showDegrees}
             scaleNotes={scaleNotes}
             holeNumber={hole.hole}
-            displayMode={noteDisplay}
           />
         )}
         {/* Blow Note - Middle */}
@@ -127,10 +117,8 @@ export const HoleColumn = memo(function HoleColumn({
           note={hole.blow.note}
           frequency={hole.blow.frequency}
           isPlayable={isBlowPlayable}
-          showDegrees={showDegrees}
           scaleNotes={scaleNotes}
           holeNumber={hole.hole}
-          displayMode={noteDisplay}
         />
       </div>
 
@@ -145,10 +133,8 @@ export const HoleColumn = memo(function HoleColumn({
           note={hole.draw.note}
           frequency={hole.draw.frequency}
           isPlayable={isDrawPlayable}
-          showDegrees={showDegrees}
           scaleNotes={scaleNotes}
           holeNumber={hole.hole}
-          displayMode={noteDisplay}
         />
         {hole.drawBends?.halfStepBend && (
           <NoteSection
@@ -156,10 +142,8 @@ export const HoleColumn = memo(function HoleColumn({
             note={hole.drawBends.halfStepBend.note}
             frequency={hole.drawBends.halfStepBend.frequency}
             isPlayable={!!isDrawHalfStepPlayable}
-            showDegrees={showDegrees}
             scaleNotes={scaleNotes}
             holeNumber={hole.hole}
-            displayMode={noteDisplay}
           />
         )}
         {hole.drawBends?.wholeStepBend && (
@@ -168,10 +152,8 @@ export const HoleColumn = memo(function HoleColumn({
             note={hole.drawBends.wholeStepBend.note}
             frequency={hole.drawBends.wholeStepBend.frequency}
             isPlayable={!!isDrawWholeStepPlayable}
-            showDegrees={showDegrees}
             scaleNotes={scaleNotes}
             holeNumber={hole.hole}
-            displayMode={noteDisplay}
           />
         )}
         {hole.drawBends?.minorThirdBend && (
@@ -180,10 +162,8 @@ export const HoleColumn = memo(function HoleColumn({
             note={hole.drawBends.minorThirdBend.note}
             frequency={hole.drawBends.minorThirdBend.frequency}
             isPlayable={!!isDrawMinorThirdPlayable}
-            showDegrees={showDegrees}
             scaleNotes={scaleNotes}
             holeNumber={hole.hole}
-            displayMode={noteDisplay}
           />
         )}
         {hole.overdraw && (
@@ -192,10 +172,8 @@ export const HoleColumn = memo(function HoleColumn({
             note={hole.overdraw.note}
             frequency={hole.overdraw.frequency}
             isPlayable={!!isOverdrawPlayable}
-            showDegrees={showDegrees}
             scaleNotes={scaleNotes}
             holeNumber={hole.hole}
-            displayMode={noteDisplay}
           />
         )}
       </div>

--- a/src/context/DisplaySettingsContext.tsx
+++ b/src/context/DisplaySettingsContext.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext, useState, type ReactNode } from 'react'
+
+export type NoteDisplayMode = 'notes' | 'tab'
+
+interface DisplaySettingsContextValue {
+  noteDisplay: NoteDisplayMode
+  showDegrees: boolean
+  setNoteDisplay: (mode: NoteDisplayMode) => void
+  setShowDegrees: (show: boolean) => void
+}
+
+const DisplaySettingsContext = createContext<DisplaySettingsContextValue | null>(null)
+
+interface DisplaySettingsProviderProps {
+  children: ReactNode
+}
+
+export function DisplaySettingsProvider({ children }: DisplaySettingsProviderProps) {
+  const [noteDisplay, setNoteDisplay] = useState<NoteDisplayMode>('notes')
+  const [showDegrees, setShowDegrees] = useState(false)
+
+  return (
+    <DisplaySettingsContext.Provider
+      value={{ noteDisplay, showDegrees, setNoteDisplay, setShowDegrees }}
+    >
+      {children}
+    </DisplaySettingsContext.Provider>
+  )
+}
+
+export function useDisplaySettings(): DisplaySettingsContextValue {
+  const context = useContext(DisplaySettingsContext)
+  if (!context) {
+    throw new Error('useDisplaySettings must be used within a DisplaySettingsProvider')
+  }
+  return context
+}

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,0 +1,1 @@
+export { DisplaySettingsProvider, useDisplaySettings, type NoteDisplayMode } from './DisplaySettingsContext'


### PR DESCRIPTION
## Summary
- Add React Context (`DisplaySettingsContext`) to manage display settings globally
- Replace prop drilling of `showDegrees` and `noteDisplay` through HoleColumn → NoteSection
- Components now consume display settings directly via `useDisplaySettings` hook

## Changes
- **New:** `src/context/DisplaySettingsContext.tsx` - Context, provider, and hook
- **New:** `src/context/index.ts` - Barrel export
- **Modified:** `src/App.tsx` - Wrap with provider, use hook for toggles
- **Modified:** `src/components/HoleColumn.tsx` - Remove display props, NoteSection uses hook

## Before → After
```
Before: App → HoleColumn → NoteSection (prop drilling)
After:  App → Provider → HoleColumn → NoteSection (context)
```

## Test Plan
- [x] All 110 tests pass
- [x] TypeScript build succeeds
- [ ] Manual: Toggle "Show Tab" button - notes switch to tab notation
- [ ] Manual: Toggle "Show Degrees" button - roman numerals appear
- [ ] Manual: Both toggles work independently

## Related
- Closes REFACTOR-002
- Review comment from PR #1

---
🤖 Generated with [Claude Code](https://claude.ai/code)