### PR TITLE
fix(position): use Circle of Fifths for harmonica position calculation

### DIFF
--- a/src/data/harmonicas.test.ts
+++ b/src/data/harmonicas.test.ts
@@ -376,41 +376,42 @@ describe('Harmonicas', () => {
       expect(getHarmonicaPosition('D', 'D')).toBe(1)
     })
 
-    it('should return 2nd position when song key is a perfect 4th above harmonica key', () => {
-      expect(getHarmonicaPosition('C', 'F')).toBe(2)
-      expect(getHarmonicaPosition('G', 'C')).toBe(2)
-      expect(getHarmonicaPosition('D', 'G')).toBe(2)
+    it('should return 2nd position when song key is a perfect 5th above harmonica key', () => {
+      expect(getHarmonicaPosition('C', 'G')).toBe(2)
+      expect(getHarmonicaPosition('G', 'D')).toBe(2)
+      expect(getHarmonicaPosition('D', 'A')).toBe(2)
     })
 
-    it('should return 3rd position when song key is a minor 7th above harmonica key', () => {
-      expect(getHarmonicaPosition('C', 'Bb')).toBe(3)
-      expect(getHarmonicaPosition('G', 'F')).toBe(3)
+    it('should return 3rd position when song key is a major 2nd above harmonica key', () => {
+      expect(getHarmonicaPosition('C', 'D')).toBe(3)
+      expect(getHarmonicaPosition('G', 'A')).toBe(3)
     })
 
     it('should handle enharmonic equivalents correctly', () => {
-      // Db/F# gives same position as C/F (2nd position, cross harp)
-      expect(getHarmonicaPosition('Db', 'F#')).toBe(2)
+      // Db/Ab gives 2nd position (Ab is a fifth above Db)
+      expect(getHarmonicaPosition('Db', 'Ab')).toBe(2)
 
-      // Standard 2nd position examples
-      expect(getHarmonicaPosition('C', 'F')).toBe(2)
-      expect(getHarmonicaPosition('G', 'C')).toBe(2)
+      // Standard 2nd position examples (song key is a fifth above harmonica key)
+      expect(getHarmonicaPosition('C', 'G')).toBe(2)
+      expect(getHarmonicaPosition('G', 'D')).toBe(2)
     })
 
-    it('should map all 12 semitone differences to positions', () => {
-      // Test all positions with C harmonica using valid HarmonicaKey values
+    it('should map all 12 positions based on circle of fifths', () => {
+      // Test all positions with C harmonica using circle of fifths
+      // Each position is one step further around the circle of fifths
       const expectedPositions: Record<HarmonicaKey, number> = {
-        'C': 1,   // 0 semitones (1st position)
-        'F': 2,   // 5 semitones (2nd position)
-        'Bb': 3,  // 10 semitones (3rd position)
-        'Eb': 4,  // 3 semitones (4th position)
-        'Ab': 5,  // 8 semitones (5th position)
-        'Db': 6,  // 1 semitone (6th position)
-        'F#': 7,  // 6 semitones (7th position)
-        'B': 8,   // 11 semitones (8th position)
-        'E': 9,   // 4 semitones (9th position)
-        'A': 10,  // 9 semitones (10th position)
-        'D': 11,  // 2 semitones (11th position)
-        'G': 12,  // 7 semitones (12th position)
+        'C': 1,   // 1st position (straight harp)
+        'G': 2,   // 2nd position (cross harp)
+        'D': 3,   // 3rd position
+        'A': 4,   // 4th position
+        'E': 5,   // 5th position
+        'B': 6,   // 6th position
+        'F#': 7,  // 7th position
+        'Db': 8,  // 8th position
+        'Ab': 9,  // 9th position
+        'Eb': 10, // 10th position
+        'Bb': 11, // 11th position
+        'F': 12,  // 12th position
       }
 
       Object.entries(expectedPositions).forEach(([songKey, expectedPosition]) => {

--- a/src/data/harmonicas.ts
+++ b/src/data/harmonicas.ts
@@ -244,30 +244,30 @@ export const SCALE_TYPES = [
 
 export type ScaleType = (typeof SCALE_TYPES)[number]
 
-// Circle of fourths: counter-clockwise on circle of fifths
-// Each step is a perfect fourth (5 semitones)
-// C -> F -> Bb -> Eb -> Ab -> Db -> Gb -> B -> E -> A -> D -> G -> C
-const CIRCLE_OF_FOURTHS: Record<string, number> = {
+// Circle of fifths: clockwise progression
+// Each step is a perfect fifth (7 semitones)
+// C -> G -> D -> A -> E -> B -> F#/Gb -> Db/C# -> Ab/G# -> Eb/D# -> Bb/A# -> F -> C
+const CIRCLE_OF_FIFTHS: Record<string, number> = {
   'C': 0,
-  'F': 1,
-  'Bb': 2, 'A#': 2,
-  'Eb': 3, 'D#': 3,
-  'Ab': 4, 'G#': 4,
-  'Db': 5, 'C#': 5,
+  'G': 1,
+  'D': 2,
+  'A': 3,
+  'E': 4,
+  'B': 5,
   'Gb': 6, 'F#': 6,
-  'B': 7,
-  'E': 8,
-  'A': 9,
-  'D': 10,
-  'G': 11,
+  'Db': 7, 'C#': 7,
+  'Ab': 8, 'G#': 8,
+  'Eb': 9, 'D#': 9,
+  'Bb': 10, 'A#': 10,
+  'F': 11,
 }
 
 // Calculate harmonica position based on harmonica key and song key
-// Positions are based on the circle of fourths (Pythagorean tuning math)
+// Positions are based on the circle of fifths
 export const getHarmonicaPosition = (harmonicaKey: HarmonicaKey, songKey: HarmonicaKey): number => {
-  const harmonicaIndex = CIRCLE_OF_FOURTHS[harmonicaKey]
-  const songIndex = CIRCLE_OF_FOURTHS[songKey]
+  const harmonicaIndex = CIRCLE_OF_FIFTHS[harmonicaKey]
+  const songIndex = CIRCLE_OF_FIFTHS[songKey]
 
-  // Count fourths from harmonica key to song key (positions are 1-indexed)
+  // Count fifths from harmonica key to song key (positions are 1-indexed)
   return ((songIndex - harmonicaIndex + 12) % 12) + 1
 }


### PR DESCRIPTION
## Summary
Fixes the harmonica position calculation to use the Circle of Fifths instead of the Circle of Fourths.

## Changes
- Replaced `CIRCLE_OF_FOURTHS` with `CIRCLE_OF_FIFTHS` lookup table
- Reordered keys to follow Circle of Fifths sequence: C → G → D → A → E → B → F#/Gb → Db/C# → Ab/G# → Eb/D# → Bb/A# → F
- Updated all position calculation tests with correct expectations

## Testing
- [x] Unit tests updated and passing (194 tests)
- [x] Manual verification:
  - C harmonica + C song = 1st position ✓
  - C harmonica + G song = 2nd position ✓
  - C harmonica + D song = 3rd position ✓

## Related
- Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)