### PR TITLE
fix: chord inversion naming uses root, not bass note

### DIFF
--- a/src/data/chords.test.ts
+++ b/src/data/chords.test.ts
@@ -244,6 +244,39 @@ describe('Chords', () => {
       expect(gMajor123?.notes).toEqual(['G3', 'B3', 'D4'])
       expect(gMajor123?.shortName).toBe('G')
     })
+
+    it('should name inverted voicings by chord root, not bass note', () => {
+      // G Major [1,2,3,4] draw has notes D4,G4,B4,D5 (D is bass, G is root)
+      // On D harmonica, this transposes to E,A,C#,E which is A Major (not E Major)
+      const dChords = getHarmonicaChords('D')
+      const inversion = dChords.find(
+        (c) =>
+          c.holes.length === 4 &&
+          c.holes[0] === 1 &&
+          c.holes[3] === 4 &&
+          c.breath === 'draw' &&
+          c.quality === 'major'
+      )
+      expect(inversion).toBeDefined()
+      expect(inversion?.shortName).toBe('A')
+      expect(inversion?.name).toBe('A Major')
+    })
+
+    it('should name inverted voicings correctly for C harmonica too', () => {
+      // G Major [1,2,3,4] draw: D4,G4,B4,D5 — root is G, not D
+      const cChords = getHarmonicaChords('C')
+      const inversion = cChords.find(
+        (c) =>
+          c.holes.length === 4 &&
+          c.holes[0] === 1 &&
+          c.holes[3] === 4 &&
+          c.breath === 'draw' &&
+          c.quality === 'major'
+      )
+      expect(inversion).toBeDefined()
+      expect(inversion?.shortName).toBe('G')
+      expect(inversion?.name).toBe('G Major')
+    })
   })
 
   describe('New API Functions', () => {

--- a/src/data/chords.ts
+++ b/src/data/chords.ts
@@ -263,28 +263,9 @@ const transposeVoicing = (
 ): ChordVoicing => {
   // Simple case - no transposition needed
   if (targetKey === 'C') {
-    const rootNote = Note.pitchClass(baseVoicing.notes[0])
-    const qualitySymbol = {
-      major: '',
-      minor: 'm',
-      dominant7: '7',
-      minor7: 'm7',
-      diminished: 'dim',
-      augmented: 'aug',
-    }[baseVoicing.quality]
-
-    const qualityName = {
-      major: 'Major',
-      minor: 'Minor',
-      dominant7: 'Dominant 7th',
-      minor7: 'Minor 7th',
-      diminished: 'Diminished',
-      augmented: 'Augmented',
-    }[baseVoicing.quality]
-
     return {
-      name: `${rootNote} ${qualityName}`,
-      shortName: `${rootNote}${qualitySymbol}`,
+      name: baseVoicing.name,
+      shortName: baseVoicing.shortName,
       quality: baseVoicing.quality,
       holes: baseVoicing.holes,
       breath: baseVoicing.breath,
@@ -309,8 +290,10 @@ const transposeVoicing = (
 
   const transposedNotes = baseVoicing.notes.map(transposeNote)
 
-  // Get the chord name from the transposed root
-  const rootNote = Note.pitchClass(transposedNotes[0])
+  // Transpose the chord root from the base voicing name, not from the first note
+  // (first note may be an inversion, e.g. G Major [1,2,3,4] has D as bass, not G)
+  const baseRoot = baseVoicing.shortName.match(/^([A-G][#b]?)/)?.[1] || Note.pitchClass(baseVoicing.notes[0])
+  const rootNote = Note.pitchClass(transposeNote(baseRoot + '4'))
   const qualitySymbol = {
     major: '',
     minor: 'm',


### PR DESCRIPTION
## Summary

- Fixes chord naming for inverted voicings where the bass note differs from the chord root
- The G Major [1,2,3,4] draw voicing has notes D,G,B,D (D is the bass in 2nd inversion). On a D harmonica this was labeled "E Major" instead of the correct "A Major"
- The `transposeVoicing` function now extracts the chord root from the base voicing name and transposes that, rather than assuming `notes[0]` is the root

## Repro

1. Select D harmonica, Song Key A (2nd position)
2. Look at the draw chord on holes 1-2-3-4
3. **Before:** Labeled "E Major" with highlighted notes E, A, C#/Db — not an E major chord
4. **After:** Correctly labeled "A Major" (A, C#, E)

## Test plan

- [x] Added test: D harmonica inversion correctly named "A Major" (not "E Major")
- [x] Added test: C harmonica inversion correctly named "G Major" (not "D Major")
- [x] All 315 existing tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)