### PR TITLE
feat: add Lee Oskar Natural Minor tuning

### DIFF
--- a/src/data/harmonicas.test.ts
+++ b/src/data/harmonicas.test.ts
@@ -228,11 +228,12 @@ describe('Harmonicas', () => {
       expect(SCALE_TYPES.length).toBeGreaterThan(0)
     })
 
-    it('should have all 5 tuning types defined', () => {
-      expect(TUNING_TYPES).toHaveLength(5)
+    it('should have all 6 tuning types defined', () => {
+      expect(TUNING_TYPES).toHaveLength(6)
       expect(TUNING_TYPES).toContain('richter')
       expect(TUNING_TYPES).toContain('paddy-richter')
       expect(TUNING_TYPES).toContain('natural-minor')
+      expect(TUNING_TYPES).toContain('lee-oskar-natural-minor')
       expect(TUNING_TYPES).toContain('country')
       expect(TUNING_TYPES).toContain('melody-maker')
     })
@@ -273,6 +274,25 @@ describe('Harmonicas', () => {
       expect(naturalMinor.holes[1].blow.note).toBe('Eb4')
       // Hole 3 draw should be Bb (minor 7th) instead of B
       expect(naturalMinor.holes[2].draw.note).toBe('Bb4')
+    })
+
+    it('Lee Oskar Natural Minor should have A (not Ab) on holes 6 and 10 draw', () => {
+      const leeOskar = getHarmonica('C', 'lee-oskar-natural-minor')
+      const naturalMinor = getHarmonica('C', 'natural-minor')
+
+      // Blow notes should be identical
+      expect(leeOskar.holes[1].blow.note).toBe('Eb4')
+
+      // Holes 6 and 10 draw: A (raised 6th) instead of Ab (flat 6th)
+      expect(naturalMinor.holes[5].draw.note).toBe('Ab5')
+      expect(leeOskar.holes[5].draw.note).toBe('A5')
+      expect(naturalMinor.holes[9].draw.note).toBe('Ab6')
+      expect(leeOskar.holes[9].draw.note).toBe('A6')
+
+      // Other draw notes should match natural minor
+      expect(leeOskar.holes[0].draw.note).toBe('D4')
+      expect(leeOskar.holes[4].draw.note).toBe('F5')
+      expect(leeOskar.holes[6].draw.note).toBe('Bb5')
     })
 
     it('Country should have raised hole 5 draw', () => {

--- a/src/data/harmonicas.ts
+++ b/src/data/harmonicas.ts
@@ -114,12 +114,13 @@ const calculateBends = (
  * - country: Hole 5 draw raised for country/bluegrass
  * - melody-maker: Lee Oskar design with multiple modifications
  */
-export type TuningType = 'richter' | 'paddy-richter' | 'natural-minor' | 'country' | 'melody-maker'
+export type TuningType = 'richter' | 'paddy-richter' | 'natural-minor' | 'lee-oskar-natural-minor' | 'country' | 'melody-maker'
 
 export const TUNING_TYPES: TuningType[] = [
   'richter',
   'paddy-richter',
   'natural-minor',
+  'lee-oskar-natural-minor',
   'country',
   'melody-maker',
 ]
@@ -142,6 +143,10 @@ const TUNINGS: Record<TuningType, TuningDefinition> = {
   'natural-minor': {
     blowNotes: ['C4', 'Eb4', 'G4', 'C5', 'Eb5', 'G5', 'C6', 'Eb6', 'G6', 'C7'],
     drawNotes: ['D4', 'G4', 'Bb4', 'D5', 'F5', 'Ab5', 'Bb5', 'D6', 'F6', 'Ab6'],
+  },
+  'lee-oskar-natural-minor': {
+    blowNotes: ['C4', 'Eb4', 'G4', 'C5', 'Eb5', 'G5', 'C6', 'Eb6', 'G6', 'C7'],
+    drawNotes: ['D4', 'G4', 'Bb4', 'D5', 'F5', 'A5', 'Bb5', 'D6', 'F6', 'A6'],
   },
   'country': {
     blowNotes: ['C4', 'E4', 'G4', 'C5', 'E5', 'G5', 'C6', 'E6', 'G6', 'C7'],


### PR DESCRIPTION
## Summary
- Adds `lee-oskar-natural-minor` as a new tuning type distinct from standard `natural-minor`
- Lee Oskar Natural Minor uses a raised 6th (A instead of Ab) on holes 6 and 10 draw
- Includes unit tests verifying the specific note differences from standard natural minor

## Test plan
- [x] All 330 existing tests pass (including 1 new test for Lee Oskar tuning)
- [ ] Verify tuning appears in UI tuning selector
- [ ] Verify correct notes display for the new tuning

🤖 Generated with [Claude Code](https://claude.com/claude-code)