### PR TITLE
feat: add Bending Practice mode with real-time pitch feedback (#83)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ npm run test:e2e:ui    # Run E2E tests in interactive UI mode
 - `useTheme`: Manages light/dark theme with localStorage persistence and system preference detection
 - `useMobileDetection`: Detects mobile devices in portrait orientation for rotate overlay
 - `useMicrophone`: Manages microphone access via MediaStream, real-time pitch detection using AnalyserNode with FFT analysis, and cleanup lifecycle
+- `useBendPractice`: Bending Practice state machine (`idle → playingTarget → userPlaying → feedback`). Plays a target tone via `playTone()`, then compares the live microphone frequency to the target in **raw cents** (`1200 * log2(detected / target)`) — bends land between chromatic notes, so the detector's rounded note is not used. Tracks hold-within-tolerance time to pass an exercise
 
 ### Contexts
 
@@ -84,6 +85,11 @@ All note transposition, interval calculation, and scale generation uses [tonal.j
 - `Legend`: Display toggles for tab notation and scale degrees
 - `RotateOverlay`: Mobile prompt to rotate device for optimal viewing
 - `PitchDetector`: Tuner strip with microphone toggle, real-time pitch visualization (note + cents offset), in-scale highlighting, and configurable A4 reference pitch
+- `BendPracticePage`: Bending Practice page (hash route `#/practice`, lazy-loaded). Key/tuning/difficulty selectors, exercise picker, and live feedback. Composes `BendTargetDisplay` (target note + hold-progress ring), `BendAccuracyMeter` (horizontal cents meter centered on the target), and `BendProgressTracker` (exercise progress bar). Exercises come from `src/data/bendExercises.ts` (`getBendExercises(key, tuning, difficulty)`)
+
+### Routing
+
+Hash-based routing via `useHashRouter` (`src/hooks/useHashRouter.ts`). Routes: `/` (Scales), `/quiz` (Quiz, lazy), `/practice` (Bending Practice, lazy). Tabs rendered by `NavHeader`.
 
 ### Dev Container
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,14 @@
 - **Chord Explorer**: Collapsible side panel showing scale-filtered chords with voicing navigation (arrows to browse different voicings) and MiniHarmonica previews on each chord card
 - **Interactive Chord Highlighting**: Click any chord to highlight its constituent holes on the harmonica
 - **Position Display**: Shows the harmonica position (1st position = straight harp, 2nd position = cross harp, etc.) calculated via Circle of Fifths
-- **Page Navigation**: Tab-based navigation between Scales and Quiz pages via NavHeader
-- **Code Splitting**: Quiz page is lazy-loaded for faster initial load
+- **Page Navigation**: Tab-based navigation between Scales, Quiz, and Practice pages via NavHeader
+- **Code Splitting**: Quiz and Practice pages are lazy-loaded for faster initial load
 - **Dark Mode**: Toggle between light and dark themes with system preference detection and localStorage persistence
 - **Mobile Support**: Portrait mobile users see a prompt to rotate their device for the best harmonica viewing experience
 - **Audio Playback**: Click any note or chord to hear it played with piano-like synthesis
 - **Keyboard Accessible**: Full keyboard navigation with Enter/Space to play notes
 - **Key Identification Quiz**: Test your ear training skills by identifying keys from chord progressions
+- **Bending Practice Mode**: Guided bend training at the `/practice` page with real-time pitch feedback — pick a target bend by difficulty, hear a reference tone, then hold the bend within tolerance while a cents-accuracy meter and hold-progress ring track your pitch (requires microphone access)
 - **Export Options**: Save harmonica diagrams as PNG or PDF, or print directly
 - **Interval Display**: Toggle to show intervals between consecutive scale notes
 - **API Documentation**: TypeDoc-generated API documentation with the rhineai theme
@@ -54,6 +55,7 @@
 ```
 src/
 ├── components/           # UI components (barrel exports via index.ts)
+│   ├── BendPractice/     # Bending practice mode with real-time pitch feedback (lazy-loaded)
 │   ├── ChordExplorer/    # Chord explorer with voicing navigation
 │   ├── ExportButton/     # PNG/PDF export button
 │   ├── HoleColumn.tsx    # Individual harmonica hole (memo-optimized)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,9 @@ import { capitalizeWords } from './utils'
 // Lazy load Quiz page - only loaded when navigating to /quiz route
 const QuizPage = lazy(() => import('./components/Quiz').then(module => ({ default: module.QuizPage })))
 
+// Lazy load Bending Practice page - only loaded when navigating to /practice route
+const BendPracticePage = lazy(() => import('./components/BendPractice').then(module => ({ default: module.BendPracticePage })))
+
 function ScalesPage() {
   const { initialParams, updateURL } = useDeepLinking()
   const [harmonicaKey, setHarmonicaKey] = useState<HarmonicaKey>(initialParams.harpKey)
@@ -228,6 +231,11 @@ function AppContent() {
         {route === '/quiz' && (
           <Suspense fallback={<div className={styles.loading}>Loading quiz...</div>}>
             <QuizPage />
+          </Suspense>
+        )}
+        {route === '/practice' && (
+          <Suspense fallback={<div className={styles.loading}>Loading practice...</div>}>
+            <BendPracticePage />
           </Suspense>
         )}
       </main>

--- a/src/components/BendPractice/BendAccuracyMeter.module.css
+++ b/src/components/BendPractice/BendAccuracyMeter.module.css
@@ -1,0 +1,109 @@
+.meter {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  width: 100%;
+}
+
+.edgeLabel {
+  flex-shrink: 0;
+  font-size: var(--font-md);
+  color: var(--color-text-muted);
+  width: 1em;
+  text-align: center;
+}
+
+.track {
+  position: relative;
+  flex: 1;
+  height: 48px;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-medium);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+/* Gray "in range" band (±15 cents → 30% of the track, centered) */
+.rangeZone {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 35%;
+  width: 30%;
+  background: var(--color-border-light);
+  opacity: 0.5;
+}
+
+/* Blue "laser accurate" band (±5 cents → 10% of the track, centered) */
+.laserZone {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 45%;
+  width: 10%;
+  background: var(--color-breath-draw-bg);
+}
+
+.centerLine {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  transform: translateX(-50%);
+  background: var(--color-border-dark);
+}
+
+.marker {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  width: 6px;
+  border-radius: 3px;
+  transform: translateX(-50%);
+  transition: left 0.08s ease-out;
+  z-index: 2;
+  background: var(--color-chord-dominant);
+}
+
+.marker.inRange {
+  background: var(--color-chord-minor);
+}
+
+.marker.laser {
+  background: var(--color-breath-draw);
+  box-shadow: 0 0 8px var(--color-breath-draw);
+}
+
+.readout {
+  flex-shrink: 0;
+  width: 3.5em;
+  text-align: right;
+  font-size: var(--font-sm);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted);
+}
+
+.readout.inRange {
+  color: var(--color-chord-minor);
+}
+
+.readout.laser {
+  color: var(--color-breath-draw);
+}
+
+.readout.off {
+  color: var(--color-chord-dominant);
+}
+
+.readout.faded {
+  opacity: 0.5;
+  color: var(--color-text-muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .marker {
+    transition: none;
+  }
+}

--- a/src/components/BendPractice/BendAccuracyMeter.tsx
+++ b/src/components/BendPractice/BendAccuracyMeter.tsx
@@ -1,0 +1,64 @@
+/**
+ * Horizontal cents meter for bend practice. The center line is the target note;
+ * the marker shows how flat/sharp the user currently is. Adapted from the
+ * PitchDetector tuner strip, but centered on the target rather than the nearest
+ * chromatic note.
+ */
+import { HOLD_TOLERANCE_CENTS, LASER_TOLERANCE_CENTS } from '../../hooks'
+import styles from './BendAccuracyMeter.module.css'
+
+interface BendAccuracyMeterProps {
+  /** Live cents offset from the target, or null when there is no signal. */
+  cents: number | null
+}
+
+/** Cents shown from center to each edge of the track. */
+const RANGE_CENTS = 50
+
+/** Maps a cents value (-RANGE..+RANGE) to a 0-100% horizontal position. */
+const centsToPercent = (cents: number): number => {
+  const clamped = Math.max(-RANGE_CENTS, Math.min(RANGE_CENTS, cents))
+  return ((clamped + RANGE_CENTS) / (2 * RANGE_CENTS)) * 100
+}
+
+export function BendAccuracyMeter({ cents }: BendAccuracyMeterProps) {
+  const hasSignal = cents !== null
+  const value = cents ?? 0
+  const absCents = Math.abs(value)
+  const category =
+    absCents <= LASER_TOLERANCE_CENTS ? 'laser' : absCents <= HOLD_TOLERANCE_CENTS ? 'inRange' : 'off'
+
+  return (
+    <div
+      className={styles.meter}
+      role="meter"
+      aria-label="Bend accuracy"
+      aria-valuemin={-RANGE_CENTS}
+      aria-valuemax={RANGE_CENTS}
+      aria-valuenow={hasSignal ? Math.round(value) : undefined}
+    >
+      <span className={styles.edgeLabel}>♭</span>
+
+      <div className={styles.track}>
+        <div className={styles.rangeZone} aria-hidden="true" />
+        <div className={styles.laserZone} aria-hidden="true" />
+        <div className={styles.centerLine} aria-hidden="true" />
+
+        {hasSignal && (
+          <div
+            className={`${styles.marker} ${styles[category]}`}
+            style={{ left: `${centsToPercent(value)}%` }}
+            data-testid="bend-marker"
+            data-category={category}
+          />
+        )}
+      </div>
+
+      <span className={styles.edgeLabel}>♯</span>
+
+      <span className={`${styles.readout} ${styles[category]} ${hasSignal ? '' : styles.faded}`}>
+        {hasSignal ? `${value > 0 ? '+' : ''}${Math.round(value)}¢` : '···'}
+      </span>
+    </div>
+  )
+}

--- a/src/components/BendPractice/BendPracticePage.module.css
+++ b/src/components/BendPractice/BendPracticePage.module.css
@@ -1,0 +1,143 @@
+.page {
+  max-width: 800px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.headerCard {
+  background: var(--color-bg-card);
+  padding: var(--spacing-lg);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  text-align: center;
+}
+
+.title {
+  margin: 0 0 var(--spacing-sm) 0;
+  font-size: var(--font-2xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.description {
+  margin: 0;
+  font-size: var(--font-base);
+  color: var(--color-text-secondary);
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--spacing-lg);
+  background: var(--color-bg-card);
+  padding: var(--spacing-lg);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+}
+
+.controlGroup {
+  display: flex;
+  flex-direction: column;
+}
+
+.controlGroup label {
+  font-weight: 600;
+  margin-bottom: var(--spacing-sm);
+  color: var(--color-text-primary);
+}
+
+.controlGroup select {
+  padding: 0.75rem;
+  border: 2px solid var(--color-border-medium);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-base);
+  cursor: pointer;
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  transition: border-color 0.3s;
+}
+
+.controlGroup select:hover {
+  border-color: var(--color-hover-border);
+}
+
+.controlGroup select:focus {
+  outline: none;
+  border-color: var(--color-hover-border);
+  box-shadow: 0 0 0 var(--focus-ring-width) var(--color-focus-ring);
+}
+
+.card,
+.practiceCard {
+  background: var(--color-bg-card);
+  padding: var(--spacing-lg);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+}
+
+.practiceCard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  align-items: center;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-md);
+  justify-content: center;
+}
+
+.micButton,
+.primaryButton,
+.secondaryButton {
+  padding: 0.6rem 1.2rem;
+  border-radius: var(--radius-md);
+  font-size: var(--font-base);
+  font-weight: 600;
+  cursor: pointer;
+  border: 2px solid var(--color-border-medium);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  transition: all 0.2s ease;
+}
+
+.micButton:hover,
+.primaryButton:hover,
+.secondaryButton:hover {
+  border-color: var(--color-hover-border);
+}
+
+.micButton.listening {
+  background: var(--color-stop-bg);
+  border-color: var(--color-stop-bg);
+  color: var(--color-text-inverse);
+}
+
+.primaryButton {
+  background: var(--color-breath-draw-bg);
+  border-color: var(--color-breath-draw-border);
+}
+
+.micButton:disabled,
+.primaryButton:disabled,
+.secondaryButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.empty {
+  margin: 0;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.error {
+  margin: 0;
+  text-align: center;
+  font-size: var(--font-sm);
+  color: var(--color-chord-dominant);
+}

--- a/src/components/BendPractice/BendPracticePage.tsx
+++ b/src/components/BendPractice/BendPracticePage.tsx
@@ -1,0 +1,207 @@
+/**
+ * Bending Practice page (route `/practice`). Lets the user pick a harmonica
+ * key, tuning, and difficulty, choose a target bend, hear a reference tone, and
+ * get real-time cents-accuracy feedback with hold detection.
+ */
+import { useMemo, useState } from 'react'
+import {
+  AVAILABLE_KEYS,
+  TUNING_TYPES,
+  BEND_DIFFICULTIES,
+  getBendExercises,
+  type HarmonicaKey,
+  type TuningType,
+  type BendDifficulty,
+} from '../../data'
+import { useBendPractice } from '../../hooks'
+import { usePitchDetection } from '../../context'
+import { capitalizeWords } from '../../utils'
+import { BendTargetDisplay } from './BendTargetDisplay'
+import { BendAccuracyMeter } from './BendAccuracyMeter'
+import { BendProgressTracker } from './BendProgressTracker'
+import styles from './BendPracticePage.module.css'
+
+export function BendPracticePage() {
+  const [harmonicaKey, setHarmonicaKey] = useState<HarmonicaKey>('C')
+  const [tuning, setTuning] = useState<TuningType>('richter')
+  const [difficulty, setDifficulty] = useState<BendDifficulty>('beginner')
+  const [exerciseIndex, setExerciseIndex] = useState(0)
+  const [completed, setCompleted] = useState<Set<number>>(new Set())
+
+  const { isListening, startListening, stopListening, isSupported, error } = usePitchDetection()
+
+  const exercises = useMemo(
+    () => getBendExercises(harmonicaKey, tuning, difficulty),
+    [harmonicaKey, tuning, difficulty]
+  )
+  const currentExercise = exercises[exerciseIndex] ?? null
+
+  const { phase, currentCents, holdProgress, passed, playTarget } = useBendPractice(currentExercise)
+
+  // Reset the set when the key / tuning / difficulty changes. Uses the React
+  // "adjust state while rendering" pattern (guarded setState during render).
+  const selectionKey = `${harmonicaKey}|${tuning}|${difficulty}`
+  const [prevSelectionKey, setPrevSelectionKey] = useState(selectionKey)
+  if (selectionKey !== prevSelectionKey) {
+    setPrevSelectionKey(selectionKey)
+    setExerciseIndex(0)
+    setCompleted(new Set())
+  }
+
+  // Record a pass for the active exercise. Guarded so it settles in one extra
+  // render rather than looping.
+  if (passed && !completed.has(exerciseIndex)) {
+    setCompleted((prev) => {
+      if (prev.has(exerciseIndex)) return prev
+      const next = new Set(prev)
+      next.add(exerciseIndex)
+      return next
+    })
+  }
+
+  const handleToggleMic = async () => {
+    if (isListening) {
+      stopListening()
+    } else {
+      try {
+        await startListening()
+      } catch (err) {
+        console.error('Failed to start microphone:', err)
+      }
+    }
+  }
+
+  const hasNext = exerciseIndex < exercises.length - 1
+
+  if (!isSupported) {
+    return (
+      <div className={styles.page}>
+        <header className={styles.headerCard}>
+          <h2 className={styles.title}>Bending Practice</h2>
+          <p className={styles.description}>
+            Pitch detection is not supported in this browser, so bending practice is unavailable.
+          </p>
+        </header>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.headerCard}>
+        <h2 className={styles.title}>Bending Practice</h2>
+        <p className={styles.description}>
+          Play the target bend and hold it steady. The meter shows how flat or sharp you are in cents.
+        </p>
+      </header>
+
+      <div className={styles.controls}>
+        <div className={styles.controlGroup}>
+          <label htmlFor="practice-key">Harmonica Key:</label>
+          <select
+            id="practice-key"
+            value={harmonicaKey}
+            onChange={(e) => setHarmonicaKey(e.target.value as HarmonicaKey)}
+          >
+            {AVAILABLE_KEYS.map((key) => (
+              <option key={key} value={key}>
+                {key}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className={styles.controlGroup}>
+          <label htmlFor="practice-tuning">Tuning:</label>
+          <select
+            id="practice-tuning"
+            value={tuning}
+            onChange={(e) => setTuning(e.target.value as TuningType)}
+          >
+            {TUNING_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {capitalizeWords(t)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className={styles.controlGroup}>
+          <label htmlFor="practice-difficulty">Difficulty:</label>
+          <select
+            id="practice-difficulty"
+            value={difficulty}
+            onChange={(e) => setDifficulty(e.target.value as BendDifficulty)}
+          >
+            {BEND_DIFFICULTIES.map((d) => (
+              <option key={d} value={d}>
+                {capitalizeWords(d)}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {exercises.length === 0 ? (
+        <div className={styles.card}>
+          <p className={styles.empty}>
+            No {difficulty} bends are available for a {harmonicaKey} {capitalizeWords(tuning)} harmonica.
+            Try a different difficulty or tuning.
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className={styles.card}>
+            <BendProgressTracker
+              exercises={exercises}
+              currentIndex={exerciseIndex}
+              completed={completed}
+              onSelect={setExerciseIndex}
+            />
+          </div>
+
+          <div className={styles.practiceCard}>
+            <BendTargetDisplay exercise={currentExercise} holdProgress={holdProgress} passed={passed} />
+
+            <BendAccuracyMeter cents={phase === 'userPlaying' || phase === 'feedback' ? currentCents : null} />
+
+            <div className={styles.actions}>
+              <button
+                type="button"
+                className={`${styles.micButton} ${isListening ? styles.listening : ''}`}
+                onClick={handleToggleMic}
+                aria-label={isListening ? 'Stop microphone' : 'Start microphone'}
+              >
+                {isListening ? '⏹ Mic' : '🎤 Mic'}
+              </button>
+
+              <button
+                type="button"
+                className={styles.primaryButton}
+                onClick={playTarget}
+                disabled={phase === 'playingTarget'}
+              >
+                {phase === 'playingTarget' ? 'Playing…' : '▶ Play target'}
+              </button>
+
+              <button
+                type="button"
+                className={styles.secondaryButton}
+                onClick={() => setExerciseIndex((i) => i + 1)}
+                disabled={!hasNext}
+              >
+                Next ›
+              </button>
+            </div>
+
+            {error && (
+              <p className={styles.error} role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/BendPractice/BendProgressTracker.module.css
+++ b/src/components/BendPractice/BendProgressTracker.module.css
@@ -1,0 +1,67 @@
+.tracker {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.label {
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.count {
+  font-size: var(--font-sm);
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.segments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.segmentItem {
+  flex: 1;
+  min-width: 16px;
+}
+
+.segment {
+  display: block;
+  width: 100%;
+  height: 10px;
+  padding: 0;
+  border: 1px solid var(--color-border-medium);
+  border-radius: var(--radius-xs);
+  background: var(--color-bg-secondary);
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.segment:hover {
+  border-color: var(--color-hover-border);
+}
+
+.segment.completed {
+  background: var(--color-playable-bg);
+  border-color: var(--color-playable-border);
+}
+
+.segment.current {
+  border-color: var(--color-breath-draw);
+  box-shadow: 0 0 0 2px var(--color-breath-draw-bg);
+}
+
+.segment:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 var(--focus-ring-width) var(--color-focus-ring);
+}

--- a/src/components/BendPractice/BendProgressTracker.tsx
+++ b/src/components/BendPractice/BendProgressTracker.tsx
@@ -1,0 +1,54 @@
+/**
+ * Progress bar across the current exercise set. Each segment is a clickable
+ * exercise; completed exercises are filled, the active one is highlighted.
+ */
+import type { BendExercise } from '../../data'
+import styles from './BendProgressTracker.module.css'
+
+interface BendProgressTrackerProps {
+  /** All exercises in the current set. */
+  exercises: BendExercise[]
+  /** Index of the active exercise. */
+  currentIndex: number
+  /** Indices of exercises the user has passed. */
+  completed: ReadonlySet<number>
+  /** Selects an exercise by index. */
+  onSelect: (index: number) => void
+}
+
+export function BendProgressTracker({
+  exercises,
+  currentIndex,
+  completed,
+  onSelect,
+}: BendProgressTrackerProps) {
+  if (exercises.length === 0) return null
+
+  return (
+    <div className={styles.tracker}>
+      <div className={styles.header}>
+        <span className={styles.label}>Progress</span>
+        <span className={styles.count}>
+          {completed.size} / {exercises.length}
+        </span>
+      </div>
+      <ol className={styles.segments} aria-label="Exercise progress">
+        {exercises.map((exercise, index) => {
+          const isCompleted = completed.has(index)
+          const isCurrent = index === currentIndex
+          return (
+            <li key={`${exercise.hole}-${exercise.bendType}`} className={styles.segmentItem}>
+              <button
+                type="button"
+                className={`${styles.segment} ${isCompleted ? styles.completed : ''} ${isCurrent ? styles.current : ''}`}
+                onClick={() => onSelect(index)}
+                aria-label={`${exercise.description}${isCompleted ? ' (completed)' : ''}`}
+                aria-current={isCurrent ? 'step' : undefined}
+              />
+            </li>
+          )
+        })}
+      </ol>
+    </div>
+  )
+}

--- a/src/components/BendPractice/BendTargetDisplay.module.css
+++ b/src/components/BendPractice/BendTargetDisplay.module.css
@@ -1,0 +1,79 @@
+.target {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.ringWrap {
+  position: relative;
+  width: 160px;
+  height: 160px;
+}
+
+.ring {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.ringTrack {
+  fill: none;
+  stroke: var(--color-border-light);
+  stroke-width: 8;
+}
+
+.ringFill {
+  fill: none;
+  stroke: var(--color-breath-draw);
+  stroke-width: 8;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.1s linear;
+}
+
+.ringPassed {
+  stroke: var(--color-playable-bg);
+}
+
+.center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+  pointer-events: none;
+}
+
+.note {
+  font-size: var(--font-2xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.freq {
+  font-size: var(--font-sm);
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.description {
+  margin: 0;
+  font-size: var(--font-base);
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+.empty {
+  margin: 0;
+  font-size: var(--font-base);
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ringFill {
+    transition: none;
+  }
+}

--- a/src/components/BendPractice/BendTargetDisplay.tsx
+++ b/src/components/BendPractice/BendTargetDisplay.tsx
@@ -1,0 +1,53 @@
+/**
+ * Target note display with a concentric ring that fills as the user holds the
+ * pitch within the tolerance zone.
+ */
+import type { BendExercise } from '../../data'
+import styles from './BendTargetDisplay.module.css'
+
+interface BendTargetDisplayProps {
+  /** The active exercise, or null when none is selected. */
+  exercise: BendExercise | null
+  /** Hold progress 0-1, drives the ring fill. */
+  holdProgress: number
+  /** Whether the user has passed the current exercise. */
+  passed: boolean
+}
+
+const RING_RADIUS = 52
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS
+
+export function BendTargetDisplay({ exercise, holdProgress, passed }: BendTargetDisplayProps) {
+  if (!exercise) {
+    return (
+      <div className={styles.target}>
+        <p className={styles.empty}>No bends available for this selection.</p>
+      </div>
+    )
+  }
+
+  const dashOffset = RING_CIRCUMFERENCE * (1 - Math.max(0, Math.min(1, holdProgress)))
+
+  return (
+    <div className={styles.target}>
+      <div className={styles.ringWrap}>
+        <svg className={styles.ring} viewBox="0 0 120 120" role="img" aria-label={`Hold progress ${Math.round(holdProgress * 100)}%`}>
+          <circle className={styles.ringTrack} cx="60" cy="60" r={RING_RADIUS} />
+          <circle
+            className={`${styles.ringFill} ${passed ? styles.ringPassed : ''}`}
+            cx="60"
+            cy="60"
+            r={RING_RADIUS}
+            strokeDasharray={RING_CIRCUMFERENCE}
+            strokeDashoffset={dashOffset}
+          />
+        </svg>
+        <div className={styles.center}>
+          <span className={styles.note}>{exercise.targetNote}</span>
+          <span className={styles.freq}>{exercise.targetFrequency.toFixed(1)} Hz</span>
+        </div>
+      </div>
+      <p className={styles.description}>{passed ? '✓ Nailed it!' : exercise.description}</p>
+    </div>
+  )
+}

--- a/src/components/BendPractice/index.ts
+++ b/src/components/BendPractice/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Bending Practice mode — guided bend exercises with real-time pitch feedback.
+ * @packageDocumentation
+ */
+export { BendPracticePage } from './BendPracticePage'
+export { BendTargetDisplay } from './BendTargetDisplay'
+export { BendAccuracyMeter } from './BendAccuracyMeter'
+export { BendProgressTracker } from './BendProgressTracker'

--- a/src/components/NavHeader/NavHeader.tsx
+++ b/src/components/NavHeader/NavHeader.tsx
@@ -33,6 +33,13 @@ export function NavHeader({ currentRoute, onNavigate, theme, onToggleTheme }: Na
         >
           Quiz
         </button>
+        <button
+          className={`${styles.navTab} ${currentRoute === '/practice' ? styles.navTabActive : ''}`}
+          onClick={() => onNavigate('/practice')}
+          aria-current={currentRoute === '/practice' ? 'page' : undefined}
+        >
+          Practice
+        </button>
       </nav>
 
       <div className={styles.actions}>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export { BendPracticePage } from './BendPractice'
 export { ChordExplorer } from './ChordExplorer'
 export { ErrorBoundary } from './ErrorBoundary'
 export { ExportButton } from './ExportButton'

--- a/src/data/bendExercises.test.ts
+++ b/src/data/bendExercises.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { getBendExercises, BEND_DIFFICULTIES } from './bendExercises'
+import { getHarmonica } from './harmonicas'
+
+describe('getBendExercises', () => {
+  describe('beginner tier', () => {
+    it('returns only holes 1, 4, 6 draw half-step bends', () => {
+      const exercises = getBendExercises('C', 'richter', 'beginner')
+
+      expect(exercises.map((e) => e.hole)).toEqual([1, 4, 6])
+      expect(exercises.every((e) => e.bendType === 'draw-half')).toBe(true)
+      expect(exercises.every((e) => e.difficulty === 'beginner')).toBe(true)
+    })
+
+    it('uses the exact note + frequency from the harmonica hole data', () => {
+      const exercises = getBendExercises('C', 'richter', 'beginner')
+      const { holes } = getHarmonica('C', 'richter')
+
+      for (const exercise of exercises) {
+        const slot = holes[exercise.hole - 1].drawBends?.halfStepBend
+        expect(slot).toBeDefined()
+        expect(exercise.targetNote).toBe(slot!.note)
+        expect(exercise.targetFrequency).toBeCloseTo(slot!.frequency, 5)
+        expect(exercise.targetFrequency).toBeGreaterThan(0)
+      }
+    })
+
+    it('includes a readable description referencing the hole and target note', () => {
+      const [first] = getBendExercises('C', 'richter', 'beginner')
+      expect(first.description).toContain('Hole 1')
+      expect(first.description).toContain(first.targetNote)
+    })
+  })
+
+  describe('intermediate tier', () => {
+    it('contains only draw bends across all bend depths', () => {
+      const exercises = getBendExercises('C', 'richter', 'intermediate')
+      const drawTypes = new Set(['draw-half', 'draw-whole', 'draw-minor-third'])
+
+      expect(exercises.length).toBeGreaterThan(0)
+      expect(exercises.every((e) => drawTypes.has(e.bendType))).toBe(true)
+    })
+
+    it('includes a minor-third draw bend (hole 3 on a C richter harp)', () => {
+      const exercises = getBendExercises('C', 'richter', 'intermediate')
+      const minorThird = exercises.filter((e) => e.bendType === 'draw-minor-third')
+
+      expect(minorThird.length).toBeGreaterThan(0)
+      expect(minorThird.some((e) => e.hole === 3)).toBe(true)
+    })
+  })
+
+  describe('advanced tier', () => {
+    it('contains only blow bends, overblows, and overdraws', () => {
+      const exercises = getBendExercises('C', 'richter', 'advanced')
+      const advancedTypes = new Set(['blow-half', 'blow-whole', 'overblow', 'overdraw'])
+
+      expect(exercises.length).toBeGreaterThan(0)
+      expect(exercises.every((e) => advancedTypes.has(e.bendType))).toBe(true)
+    })
+
+    it('includes overblows on holes 1, 4, 5, 6', () => {
+      const overblowHoles = getBendExercises('C', 'richter', 'advanced')
+        .filter((e) => e.bendType === 'overblow')
+        .map((e) => e.hole)
+
+      expect(overblowHoles).toEqual([1, 4, 5, 6])
+    })
+  })
+
+  describe('tuning sensitivity', () => {
+    it('produces a different intermediate set for country tuning (hole 5 draw bends)', () => {
+      const richter = getBendExercises('C', 'richter', 'intermediate')
+      const country = getBendExercises('C', 'country', 'intermediate')
+
+      // Richter hole 5 (E5 blow / F5 draw, 1 semitone apart) has no draw bend;
+      // country raises the hole 5 draw to F#5, opening a half-step bend.
+      expect(richter.some((e) => e.hole === 5)).toBe(false)
+      expect(country.some((e) => e.hole === 5)).toBe(true)
+    })
+  })
+
+  describe('robustness', () => {
+    it('never emits an exercise with a zero or missing target frequency', () => {
+      for (const difficulty of BEND_DIFFICULTIES) {
+        const exercises = getBendExercises('A', 'richter', difficulty)
+        expect(exercises.every((e) => e.targetFrequency > 0)).toBe(true)
+        expect(exercises.every((e) => typeof e.targetNote === 'string' && e.targetNote.length > 0)).toBe(true)
+      }
+    })
+  })
+})

--- a/src/data/bendExercises.ts
+++ b/src/data/bendExercises.ts
@@ -1,0 +1,135 @@
+/**
+ * Bend exercise generation for the Bending Practice mode.
+ *
+ * Extracts the pre-computed bend / extended-technique frequencies from a
+ * harmonica's hole data ({@link getHarmonica}) and groups them into graded
+ * practice exercises. The note frequencies are produced by tonal.js at the
+ * standard A4 = 440 Hz reference; the practice hook compares them against the
+ * raw detected frequency, so reference-pitch tuning does not enter here.
+ * @packageDocumentation
+ */
+import { getHarmonica } from './harmonicas'
+import type { HarmonicaKey, HarmonicaNote, HoleNote, TuningType } from './harmonicas'
+
+/** A specific bend or extended technique on a hole. */
+export type BendType =
+  | 'draw-half'
+  | 'draw-whole'
+  | 'draw-minor-third'
+  | 'blow-half'
+  | 'blow-whole'
+  | 'overblow'
+  | 'overdraw'
+
+/** Difficulty tier for a set of bend exercises. */
+export type BendDifficulty = 'beginner' | 'intermediate' | 'advanced'
+
+/** Selectable difficulty tiers, in order, for UI controls. */
+export const BEND_DIFFICULTIES: BendDifficulty[] = ['beginner', 'intermediate', 'advanced']
+
+/** A single guided bending exercise: one target note on one hole. */
+export interface BendExercise {
+  /** Hole number (1-10). */
+  hole: number
+  /** Which bend / technique produces the target. */
+  bendType: BendType
+  /** Target note name (e.g. "Db4"). */
+  targetNote: string
+  /** Target frequency in Hz (A4 = 440 reference). */
+  targetFrequency: number
+  /** Difficulty tier this exercise belongs to. */
+  difficulty: BendDifficulty
+  /** Human-readable one-line description. */
+  description: string
+}
+
+/** Human-readable label for each bend type, used in exercise descriptions. */
+const BEND_LABELS: Record<BendType, string> = {
+  'draw-half': 'draw half-step bend',
+  'draw-whole': 'draw whole-step bend',
+  'draw-minor-third': 'draw minor-third bend',
+  'blow-half': 'blow half-step bend',
+  'blow-whole': 'blow whole-step bend',
+  overblow: 'overblow',
+  overdraw: 'overdraw',
+}
+
+/** Holes whose draw half-step bend is the easiest to learn first. */
+const BEGINNER_HOLES = [1, 4, 6]
+/** Draw bend types, easiest to hardest, for the intermediate tier. */
+const DRAW_BEND_TYPES: BendType[] = ['draw-half', 'draw-whole', 'draw-minor-third']
+/** Advanced techniques: blow bends and over-bends. */
+const ADVANCED_BEND_TYPES: BendType[] = ['blow-half', 'blow-whole', 'overblow', 'overdraw']
+
+/** Resolves the note for a given bend type on a hole, if it exists for this tuning. */
+const getBendNote = (hole: HoleNote, bendType: BendType): HarmonicaNote | undefined => {
+  switch (bendType) {
+    case 'draw-half':
+      return hole.drawBends?.halfStepBend
+    case 'draw-whole':
+      return hole.drawBends?.wholeStepBend
+    case 'draw-minor-third':
+      return hole.drawBends?.minorThirdBend
+    case 'blow-half':
+      return hole.blowBends?.halfStepBend
+    case 'blow-whole':
+      return hole.blowBends?.wholeStepBend
+    case 'overblow':
+      return hole.overblow
+    case 'overdraw':
+      return hole.overdraw
+  }
+}
+
+/** Builds an exercise from a hole + bend type, or undefined if the bend is unavailable. */
+const makeExercise = (
+  hole: HoleNote,
+  bendType: BendType,
+  difficulty: BendDifficulty
+): BendExercise | undefined => {
+  const note = getBendNote(hole, bendType)
+  if (!note || !note.frequency) return undefined
+  return {
+    hole: hole.hole,
+    bendType,
+    targetNote: note.note,
+    targetFrequency: note.frequency,
+    difficulty,
+    description: `Hole ${hole.hole} ${BEND_LABELS[bendType]} → ${note.note}`,
+  }
+}
+
+/**
+ * Generates the bend exercises for a harmonica at a given difficulty.
+ *
+ * - **beginner**: holes 1, 4, 6 draw half-step bends (physically easiest).
+ * - **intermediate**: every available draw bend (half / whole / minor-third).
+ * - **advanced**: blow bends, overblows, and overdraws.
+ *
+ * Bend slots that do not exist for the selected tuning are skipped, so the
+ * returned list adapts to alternate tunings automatically.
+ */
+export const getBendExercises = (
+  harmonicaKey: HarmonicaKey,
+  tuning: TuningType,
+  difficulty: BendDifficulty
+): BendExercise[] => {
+  const { holes } = getHarmonica(harmonicaKey, tuning)
+  const exercises: BendExercise[] = []
+
+  for (const hole of holes) {
+    if (difficulty === 'beginner') {
+      if (!BEGINNER_HOLES.includes(hole.hole)) continue
+      const exercise = makeExercise(hole, 'draw-half', 'beginner')
+      if (exercise) exercises.push(exercise)
+    } else {
+      const bendTypes = difficulty === 'intermediate' ? DRAW_BEND_TYPES : ADVANCED_BEND_TYPES
+      for (const bendType of bendTypes) {
+        const exercise = makeExercise(hole, bendType, difficulty)
+        if (exercise) exercises.push(exercise)
+      }
+    }
+  }
+
+  return exercises
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -56,3 +56,12 @@ export {
   generateQuestion,
   ALL_KEYS,
 } from './progressions'
+
+// Re-export everything from bendExercises
+export {
+  type BendType,
+  type BendDifficulty,
+  type BendExercise,
+  BEND_DIFFICULTIES,
+  getBendExercises,
+} from './bendExercises'

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,3 +8,12 @@ export { useHashRouter, type Route } from './useHashRouter'
 export { useMobileDetection } from './useMobileDetection'
 export { useMicrophone, type UseMicrophoneResult } from './useMicrophone'
 export { useDeepLinking, parseDeepLinkParams, parseHashQueryParams, buildHashWithParams, type DeepLinkParams } from './useDeepLinking'
+export {
+  useBendPractice,
+  centsBetween,
+  HOLD_TOLERANCE_CENTS,
+  LASER_TOLERANCE_CENTS,
+  HOLD_DURATION_MS,
+  type BendPracticePhase,
+  type UseBendPracticeResult,
+} from './useBendPractice'

--- a/src/hooks/useBendPractice.test.ts
+++ b/src/hooks/useBendPractice.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  useBendPractice,
+  centsBetween,
+  HOLD_DURATION_MS,
+} from './useBendPractice'
+import type { PitchResult } from '../utils/pitchDetection'
+import type { BendExercise } from '../data'
+
+// Controllable pitch-detection state shared with the mocked context.
+const mockState = vi.hoisted(() => ({
+  pitchResult: null as PitchResult | null,
+  isListening: false,
+  startListening: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../context', () => ({
+  usePitchDetection: () => ({
+    isListening: mockState.isListening,
+    startListening: mockState.startListening,
+    stopListening: vi.fn(),
+    pitchResult: mockState.pitchResult,
+    lastPitchResult: null,
+    error: null,
+    isSupported: true,
+    setDebugMode: vi.fn(),
+    referenceHz: 440,
+    setReferenceHz: vi.fn(),
+  }),
+}))
+
+vi.mock('../utils', () => ({
+  playTone: vi.fn().mockResolvedValue(undefined),
+}))
+
+const EXERCISE: BendExercise = {
+  hole: 4,
+  bendType: 'draw-half',
+  targetNote: 'A4',
+  targetFrequency: 440,
+  difficulty: 'beginner',
+  description: 'test exercise',
+}
+
+const pitch = (frequency: number): PitchResult => ({
+  frequency,
+  note: 'A4',
+  cents: 0,
+  confidence: 1,
+})
+
+describe('centsBetween', () => {
+  it('is zero when frequencies match', () => {
+    expect(centsBetween(440, 440)).toBe(0)
+  })
+
+  it('is +1200 cents an octave up and -1200 an octave down', () => {
+    expect(centsBetween(880, 440)).toBeCloseTo(1200, 5)
+    expect(centsBetween(220, 440)).toBeCloseTo(-1200, 5)
+  })
+})
+
+describe('useBendPractice', () => {
+  let nowSpy: ReturnType<typeof vi.spyOn>
+  let rafCallback: FrameRequestCallback | null
+
+  beforeEach(() => {
+    mockState.pitchResult = null
+    mockState.isListening = false
+    mockState.startListening = vi.fn().mockResolvedValue(undefined)
+    nowSpy = vi.spyOn(performance, 'now').mockReturnValue(0)
+    rafCallback = null
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      rafCallback = cb
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    nowSpy.mockRestore()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('starts idle', () => {
+    const { result } = renderHook(() => useBendPractice(EXERCISE))
+    expect(result.current.phase).toBe('idle')
+    expect(result.current.passed).toBe(false)
+    expect(result.current.holdProgress).toBe(0)
+  })
+
+  it('arms the listener after playing the target tone', async () => {
+    const { result } = renderHook(() => useBendPractice(EXERCISE))
+    await act(async () => {
+      await result.current.playTarget()
+    })
+    expect(result.current.phase).toBe('userPlaying')
+    expect(mockState.startListening).toHaveBeenCalled()
+  })
+
+  /**
+   * Advances one animation frame: pushes a new pitch reading (synced into the
+   * hook's ref via rerender) at the given time, then invokes the captured rAF
+   * callback.
+   */
+  const stepFrame = (
+    rerender: () => void,
+    frequency: number | null,
+    now: number
+  ) => {
+    mockState.pitchResult = frequency === null ? null : pitch(frequency)
+    nowSpy.mockReturnValue(now)
+    act(() => rerender())
+    act(() => rafCallback?.(now))
+  }
+
+  it('accumulates hold progress and passes after the hold duration', async () => {
+    const { result, rerender } = renderHook(() => useBendPractice(EXERCISE))
+    await act(async () => {
+      await result.current.playTarget()
+    })
+
+    // First on-target frame establishes the baseline timestamp.
+    stepFrame(rerender, 440, 0)
+    expect(result.current.holdProgress).toBe(0)
+
+    // 1000ms later, still on target (441Hz is ~3.9 cents).
+    stepFrame(rerender, 441, 1000)
+    expect(result.current.holdProgress).toBeCloseTo(1000 / HOLD_DURATION_MS, 2)
+    expect(result.current.passed).toBe(false)
+
+    // Crossing the hold threshold passes the exercise.
+    stepFrame(rerender, 440, 1600)
+    expect(result.current.holdProgress).toBe(1)
+    expect(result.current.passed).toBe(true)
+    expect(result.current.phase).toBe('feedback')
+  })
+
+  it('resets hold progress when the pitch drifts out of tolerance', async () => {
+    const { result, rerender } = renderHook(() => useBendPractice(EXERCISE))
+    await act(async () => {
+      await result.current.playTarget()
+    })
+
+    stepFrame(rerender, 440, 0)
+    stepFrame(rerender, 440, 700)
+    expect(result.current.holdProgress).toBeGreaterThan(0)
+
+    // 466Hz is ~100 cents sharp — well outside the 15 cent window.
+    stepFrame(rerender, 466, 900)
+    expect(result.current.holdProgress).toBe(0)
+    expect(result.current.passed).toBe(false)
+    expect(result.current.currentCents).toBeCloseTo(centsBetween(466, 440), 5)
+  })
+
+  it('reset() returns the loop to idle', async () => {
+    const { result, rerender } = renderHook(() => useBendPractice(EXERCISE))
+    await act(async () => {
+      await result.current.playTarget()
+    })
+    stepFrame(rerender, 440, 0)
+
+    act(() => result.current.reset())
+    expect(result.current.phase).toBe('idle')
+    expect(result.current.currentCents).toBeNull()
+    expect(result.current.holdProgress).toBe(0)
+  })
+})

--- a/src/hooks/useBendPractice.ts
+++ b/src/hooks/useBendPractice.ts
@@ -1,0 +1,175 @@
+/**
+ * Practice state machine for the Bending Practice mode.
+ *
+ * Drives one bend exercise at a time through the phases
+ * `idle → playingTarget → userPlaying → feedback`. It plays a reference tone
+ * for the target, then measures the live microphone pitch against the target
+ * in raw cents.
+ *
+ * Crucially, bends land *between* the chromatic notes, so the rounded note from
+ * the pitch detector is useless here — we compute cents directly from the raw
+ * detected frequency vs. the target frequency. Both are absolute Hz, so the A4
+ * reference-pitch setting does not affect the comparison.
+ * @packageDocumentation
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { usePitchDetection } from '../context'
+import { playTone } from '../utils'
+import type { BendExercise } from '../data'
+
+/** Phases of a single bend exercise. */
+export type BendPracticePhase = 'idle' | 'playingTarget' | 'userPlaying' | 'feedback'
+
+/** Cents window within which the user's pitch counts as "on target". */
+export const HOLD_TOLERANCE_CENTS = 15
+/** Tighter window used for "laser accurate" UI feedback. */
+export const LASER_TOLERANCE_CENTS = 5
+/** How long the user must hold the target (ms) to pass the exercise. */
+export const HOLD_DURATION_MS = 1500
+/** Duration of the reference target tone (seconds). */
+const TARGET_TONE_DURATION_S = 1.2
+
+/**
+ * Cents difference of a detected frequency from a target frequency.
+ * Positive = sharp, negative = flat.
+ */
+export const centsBetween = (detectedFrequency: number, targetFrequency: number): number =>
+  1200 * Math.log2(detectedFrequency / targetFrequency)
+
+/** Stable identity for an exercise, used to detect when the target changes. */
+const exerciseKeyOf = (exercise: BendExercise | null): string | null =>
+  exercise ? `${exercise.hole}-${exercise.bendType}` : null
+
+/** State and actions returned by {@link useBendPractice}. */
+export interface UseBendPracticeResult {
+  /** Current phase of the exercise. */
+  phase: BendPracticePhase
+  /** Live cents offset from the target, or null when there is no input signal. */
+  currentCents: number | null
+  /** Progress holding the target in the tolerance zone, 0-1. */
+  holdProgress: number
+  /** True once the user has held the target long enough to pass. */
+  passed: boolean
+  /** Plays the reference tone, then arms the listener for the user's attempt. */
+  playTarget: () => Promise<void>
+  /** Resets the exercise back to idle. */
+  reset: () => void
+}
+
+/**
+ * Runs the bend practice loop for a single exercise.
+ * @param exercise - The active exercise, or null when none is selected.
+ */
+export function useBendPractice(exercise: BendExercise | null): UseBendPracticeResult {
+  const { isListening, startListening, pitchResult } = usePitchDetection()
+
+  const [phase, setPhase] = useState<BendPracticePhase>('idle')
+  const [currentCents, setCurrentCents] = useState<number | null>(null)
+  const [holdProgress, setHoldProgress] = useState(0)
+  const [passed, setPassed] = useState(false)
+
+  // Latest pitch result, kept in a ref so the animation-frame loop always reads
+  // the current value without re-subscribing every frame.
+  const pitchRef = useRef(pitchResult)
+  useEffect(() => {
+    pitchRef.current = pitchResult
+  }, [pitchResult])
+
+  // Accumulated in-tolerance hold time and the timestamp of the previous
+  // in-tolerance frame.
+  const holdAccumRef = useRef(0)
+  const lastTsRef = useRef<number | null>(null)
+
+  const clearHold = useCallback(() => {
+    holdAccumRef.current = 0
+    lastTsRef.current = null
+  }, [])
+
+  const reset = useCallback(() => {
+    setPhase('idle')
+    setCurrentCents(null)
+    setHoldProgress(0)
+    setPassed(false)
+    clearHold()
+  }, [clearHold])
+
+  const playTarget = useCallback(async () => {
+    if (!exercise) return
+    setPassed(false)
+    setHoldProgress(0)
+    setPhase('playingTarget')
+    await playTone(exercise.targetFrequency, TARGET_TONE_DURATION_S)
+    if (!isListening) {
+      try {
+        await startListening()
+      } catch {
+        /* mic permission denied — the meter simply stays idle */
+      }
+    }
+    setPhase('userPlaying')
+  }, [exercise, isListening, startListening])
+
+  // Reset the loop whenever the target exercise changes. Uses the React
+  // "adjust state while rendering" pattern (guarded setState during render)
+  // rather than an effect, so the reset is applied before the next paint.
+  const exerciseKey = exerciseKeyOf(exercise)
+  const [prevExerciseKey, setPrevExerciseKey] = useState(exerciseKey)
+  if (exerciseKey !== prevExerciseKey) {
+    setPrevExerciseKey(exerciseKey)
+    setPhase('idle')
+    setCurrentCents(null)
+    setHoldProgress(0)
+    setPassed(false)
+  }
+
+  // While the user is playing, sample the latest pitch each animation frame and
+  // accumulate hold time. setState lives inside the frame callback (an external
+  // timer subscription), keeping it off the effect's synchronous path.
+  useEffect(() => {
+    if (phase !== 'userPlaying' || !exercise) return
+
+    // Start each attempt with a clean hold streak.
+    holdAccumRef.current = 0
+    lastTsRef.current = null
+
+    let frame = 0
+    const tick = () => {
+      const frequency = pitchRef.current?.frequency
+      const now = performance.now()
+
+      if (!frequency) {
+        // Signal dropped — break the hold streak but keep accumulated progress.
+        lastTsRef.current = null
+        setCurrentCents(null)
+        frame = requestAnimationFrame(tick)
+        return
+      }
+
+      const cents = centsBetween(frequency, exercise.targetFrequency)
+      setCurrentCents(cents)
+
+      if (Math.abs(cents) <= HOLD_TOLERANCE_CENTS) {
+        if (lastTsRef.current !== null) {
+          holdAccumRef.current += now - lastTsRef.current
+        }
+        lastTsRef.current = now
+        setHoldProgress(Math.min(1, holdAccumRef.current / HOLD_DURATION_MS))
+        if (holdAccumRef.current >= HOLD_DURATION_MS) {
+          setPassed(true)
+          setPhase('feedback')
+          return
+        }
+      } else {
+        clearHold()
+        setHoldProgress(0)
+      }
+
+      frame = requestAnimationFrame(tick)
+    }
+
+    frame = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(frame)
+  }, [phase, exercise, clearHold])
+
+  return { phase, currentCents, holdProgress, passed, playTarget, reset }
+}

--- a/src/hooks/useHashRouter.ts
+++ b/src/hooks/useHashRouter.ts
@@ -4,11 +4,12 @@
  */
 import { useState, useEffect, useCallback } from 'react'
 
-export type Route = '/' | '/quiz'
+export type Route = '/' | '/quiz' | '/practice'
 
 function parseHash(): Route {
   const hash = window.location.hash
   if (hash === '#/quiz') return '/quiz'
+  if (hash === '#/practice') return '/practice'
   return '/'
 }
 


### PR DESCRIPTION
Closes #83

## Summary

New `/practice` page for guided bend training with real-time pitch feedback. Pick a target bend by difficulty, hear a reference tone, then hold the bend while a cents-accuracy meter and hold-progress ring track the live microphone pitch. Built entirely on existing primitives (`PitchDetectionContext`, `playTone()`, pre-computed `HoleNote` bend frequencies).

## What's new

- **`src/data/bendExercises.ts`** — `getBendExercises(key, tuning, difficulty)` extracts bend/extended-technique frequencies from `getHarmonica().holes`, graded:
  - *Beginner*: holes 1/4/6 draw half-step bends
  - *Intermediate*: all draw bends (half / whole / minor-third)
  - *Advanced*: blow bends, overblows, overdraws
  - Unavailable slots are skipped, so the set adapts to alternate tunings.
- **`src/hooks/useBendPractice.ts`** — `idle → playingTarget → userPlaying → feedback` state machine. Compares the **raw** detected frequency to the target in cents (`1200·log2(detected/target)`) — bends land *between* chromatic notes, so the detector's rounded note isn't used; reference-Hz is irrelevant since both values are absolute Hz. Per-frame sampling via `requestAnimationFrame`; holding within ±15¢ for ~1.5s passes.
- **`src/components/BendPractice/`** — `BendPracticePage` + `BendTargetDisplay` (note + hold-progress ring), `BendAccuracyMeter` (target-centered cents meter adapted from `PitchDetector`), `BendProgressTracker`.
- Wiring: `/practice` route in `useHashRouter`, lazy import + Suspense in `App.tsx`, Practice tab in `NavHeader`, barrel re-exports.
- Docs: README + CLAUDE updated for the new page/route.

## Tests

- `bendExercises.test.ts` (9) — tier categorization, exact note/frequency extraction, tuning sensitivity (country hole-5), no zero-frequency exercises.
- `useBendPractice.test.ts` (7) — raw-cents math, hold accumulation, pass threshold, out-of-tolerance reset, reset action.

## Verification

`npm run build` ✓ · `eslint .` ✓ · `tsc --noEmit` ✓ · `npm test` ✓ (369 passed / 1 pre-existing skip) · production preview returns 200; `BendPracticePage` code-splits into its own chunk.

Manual: navigate to `#/practice` → select a bend → Play target (reference tone) → enable mic → meter tracks pitch, holding in tolerance fills the ring and advances to a passed state. Switching tuning/difficulty updates the exercise set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)